### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     multi_json (1.10.1)
     multi_test (0.1.2)
     nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+      mini_portile (~> 1.8.1)
     pg (0.15.1)
     polyglot (0.3.5)
     rack (1.5.2)


### PR DESCRIPTION
Known critical severity security vulnerability detected in nokogiri < 1.8.1 defined in Gemfile.lock.
Gemfile.lock update suggested: nokogiri ~> 1.8.1.